### PR TITLE
Upgrade to Netty 3.9.3.Final to match Play 2.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-            <version>3.6.3.Final</version>
+            <version>3.9.3.Final</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Upgrades the pom.xml to Netty 3.9.3.Final

Reason: 1.1.2 uses Netty 3.6.3.Final, while Play 2.3.7 uses Netty 3.9.3.Final.  When using a Play project with SBT 0.13.7, the project produces the following warning:

[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]     * io.netty:netty:3.6.3.Final -> 3.9.3.Final (caller: com.typesafe.netty:netty-http-pipelining:1.1.2, com.typesafe.play:play_2.11:2.3.7, com.typesafe.netty:netty-http-pipelining:1.1.2, com.typesafe.play:play_2.11:2.3.7)

adding an exclusion rule:

ExclusionRule(organization = "com.typesafe.netty", name = "netty-http-pipelining") // uses netty 3.6.3.Final, causes eviction

prevents the old Netty from being added, but at the cost of the library.  