### PR TITLE
Fix Maven compilation by specifying source and target levels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,26 @@
         </dependency>
     </dependencies>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.2</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+
     <scm>
         <connection>scm:git://github.com/typesafehub/netty-http-pipelining.git</connection>
         <developerConnection>scm:git:git@github.com:typesafehub/netty-http-pipelining.git</developerConnection>
         <url>scm:git://github.com/typesafehub/netty-http-pipelining.git</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
I get errors compiling without this change

>[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project netty-http-pipelining: Compilation failure: Compilation failure:
[ERROR] /home/bmccann/src/netty-http-pipelining/src/main/java/com/typesafe/netty/http/pipelining/OrderedDownstreamChannelEvent.java:[64,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable annotations)
[ERROR] /home/bmccann/src/netty-http-pipelining/src/main/java/com/typesafe/netty/http/pipelining/HttpPipeliningHandler.java:[27,23] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /home/bmccann/src/netty-http-pipelining/src/main/java/com/typesafe/netty/http/pipelining/HttpPipeliningHandler.java:[42,13] error: annotations are not supported in -source 1.3
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
