### PR TITLE
Switched to publishing to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <artifactId>netty-http-pipelining</artifactId>
     <version>1.1.4-SNAPSHOT</version>
 
-    <description>This library provides a handler and some new message types that enable http pipelining in Netty
-    </description>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>This library provides a handler and some new message types that enable http pipelining in Netty</description>
     <inceptionYear>2013</inceptionYear>
     <url>https://github.com/typesafehub/netty-http-pipelining</url>
 
@@ -23,6 +23,15 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <name>Christopher Hunt</name>
+            <email>christopher.hunt@typesafe.com</email>
+            <organization>Typesafe</organization>
+            <organizationUrl>http://typesafe.com</organizationUrl>
+        </developer>
+    </developers>
 
     <organization>
         <name>Typesafe</name>
@@ -45,33 +54,101 @@
 
     <build>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
-          <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-          </configuration>
-        </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.2</version>
+              <configuration>
+                  <source>1.7</source>
+                  <target>1.7</target>
+              </configuration>
+          </plugin>
+          <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nexus-staging-maven-plugin</artifactId>
+              <version>1.6.3</version>
+              <extensions>true</extensions>
+              <configuration>
+                  <serverId>ossrh</serverId>
+                  <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                  <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              </configuration>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <version>2.5</version>
+              <configuration>
+                  <autoVersionSubmodules>true</autoVersionSubmodules>
+                  <useReleaseProfile>false</useReleaseProfile>
+                  <releaseProfiles>release</releaseProfiles>
+                  <goals>deploy</goals>
+              </configuration>
+          </plugin>
       </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <scm>
         <connection>scm:git://github.com/typesafehub/netty-http-pipelining.git</connection>
         <developerConnection>scm:git:git@github.com:typesafehub/netty-http-pipelining.git</developerConnection>
         <url>scm:git://github.com/typesafehub/netty-http-pipelining.git</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>
-        <repository>
-            <id>typesafe-releases</id>
-            <url>https://private-repo.typesafe.com/typesafe/maven-releases/</url>
-        </repository>
         <snapshotRepository>
-            <id>typesafe-snapshots</id>
-            <url>https://private-repo.typesafe.com/typesafe/maven-snapshots/</url>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
Typesafe is deprecating it's artifdactory repositories (repo.typesafe.com), making them read only, so this project can no longer be published there.

Also, by switching to maven central, we allow Play to no longer need an explicit dependency on the typesafe resolvers.

Followed instructions/requirements here to do this:

* http://central.sonatype.org/pages/requirements.html
* http://central.sonatype.org/pages/apache-maven.html